### PR TITLE
feat: support for ai-sdk via .env.local for those that don't have the AI gateway configured in Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# x402 Next.js + AI Starter Kit
+<div align="center">
+  <h1>x402 Next.js + AI Starter Kit</h1>
+  
+  [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
+</div>
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
-
-![Screenshot of the app](./public/screenshot.png)
+<div align="center">
+  <img src="./public/screenshot.png" alt="Screenshot of the app" width="75%" />
+</div>
 
 [x402](https://x402.org) is a new protocol built on top of HTTP for doing fully accountless payments easily, quickly, cheaply and securely.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pnpm install
 Using AI Gateway requires either a Vercel OIDC token, or an API Key.
 To get an OIDC token, simply run `vc link` then `vc env pull`. An API can be obtained from the [AI Gateway dashboard](https://vercel.com/ai-gateway).
 
-Using AI Gateway isn't required, you can use any AI SDK model provider and its associated credentials.
+Using AI Gateway isn't required, you can use any AI SDK model provider and its associated credentials. The app includes a provider mode selector to switch between AI Gateway and direct AI SDK access (e.g., using `OPENAI_API_KEY`).
 
 3. Run `pnpm dev`
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <div align="center">
   <h1>x402 Next.js + AI Starter Kit</h1>
+
+  [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
   
   <img src="./public/screenshot.png" alt="Screenshot of the app" width="80%" />
   
-  [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
 </div>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 <div align="center">
   <h1>x402 Next.js + AI Starter Kit</h1>
   
+  <img src="./public/screenshot.png" alt="Screenshot of the app" width="80%" />
+  
   [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
 </div>
 
 <div align="center">
-  <img src="./public/screenshot.png" alt="Screenshot of the app" width="75%" />
-</div>
-
+  
 [x402](https://x402.org) is a new protocol built on top of HTTP for doing fully accountless payments easily, quickly, cheaply and securely.
 
 This template built with [Next.js](https://nextjs.org), [AI SDK](https://ai-sdk.dev), [AI Elements](https://ai-elements.dev), and [AI Gateway](https://vercel.com/ai-gateway) and the [Coinbase CDP](https://docs.cdp.coinbase.com/) shows off using x402 with a modern AI stack.
 
 **Demo: [https://x402-ai-starter.vercel.app/](https://x402-ai-starter.vercel.app/)**
+
+</div>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-labs%2Fx402-ai-starter&env=CDP_API_KEY_ID,CDP_API_KEY_SECRET,CDP_WALLET_SECRET&envDescription=Coinbase%20Developer%20Platform%20credentials%20are%20needed%20to%20create%20and%20fund%20server%20wallets&envLink=https%3A%2F%2Fdocs.cdp.coinbase.com%2Fapi-reference%2Fv2%2Fauthentication&project-name=x402-ai-starter&repository-name=x402-ai-starter&demo-title=x402%20AI%20Starter&demo-description=A%20fullstack%20template%20for%20using%20x402%20with%20MCP%20and%20AI%20SDK&demo-url=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2F&demo-image=https%3A%2F%2Fx402-ai-starter.labs.vercel.dev%2Fscreenshot.png)
 
-![Screenshot of the app](./public/screenshot-small.png)
+![Screenshot of the app](./public/screenshot.png)
 
 [x402](https://x402.org) is a new protocol built on top of HTTP for doing fully accountless payments easily, quickly, cheaply and securely.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/google": "^2.0.14",
+    "@ai-sdk/openai": "^2.0.30",
     "@ai-sdk/react": "^2.0.26",
     "@coinbase/cdp-sdk": "^1.36.0",
     "@coinbase/x402": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/google':
+        specifier: ^2.0.14
+        version: 2.0.14(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^2.0.30
+        version: 2.0.30(zod@3.25.76)
       '@ai-sdk/react':
         specifier: ^2.0.26
         version: 2.0.39(react@19.1.0)(zod@3.25.76)
@@ -153,8 +159,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/google@2.0.14':
+    resolution: {integrity: sha512-OCBBkEUq1RNLkbJuD+ejqGsWDD0M5nRyuFWDchwylxy0J4HSsAiGNhutNYVTdnqmNw+r9LyZlkyZ1P4YfAfLdg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/openai@2.0.30':
+    resolution: {integrity: sha512-a9Vf64OT2dWEFyEGv+OxtCs69B18BsuzInvuyUxVPczbIiBLqUCt3zcD/8EwqbTPJwsFNsL8/9nbVZFmwA1+2A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider-utils@3.0.8':
     resolution: {integrity: sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.9':
+    resolution: {integrity: sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -4417,7 +4441,26 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.8(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/google@2.0.14(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/openai@2.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@3.0.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.9(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { convertToModelMessages, stepCountIs, streamText, UIMessage } from "ai";
+import { convertToModelMessages, stepCountIs, streamText, UIMessage, createProviderRegistry } from "ai";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { experimental_createMCPClient as createMCPClient } from "ai";
 import { withPayment } from "x402-mcp";
@@ -6,11 +6,18 @@ import { tool } from "ai";
 import z from "zod";
 import { getOrCreatePurchaserAccount } from "@/lib/accounts";
 import { env } from "@/lib/env";
+import { openai } from "@ai-sdk/openai";
+import { google } from "@ai-sdk/google";
 
 export const maxDuration = 30;
 
+const registry = createProviderRegistry({
+  openai,
+  google
+});
+
 export const POST = async (request: Request) => {
-  const { messages, model }: { messages: UIMessage[]; model: string } =
+  const { messages, model, providerMode = "gateway" }: { messages: UIMessage[]; model: string; providerMode?: string } =
     await request.json();
 
   const account = await getOrCreatePurchaserAccount();
@@ -21,8 +28,12 @@ export const POST = async (request: Request) => {
 
   const tools = await mcpClient.tools();
 
+  const modelToUse = providerMode === "sdk" 
+    ? registry.languageModel(model.replace('/', ':') as Parameters<typeof registry.languageModel>[0])
+    : model;
+
   const result = streamText({
-    model,
+    model: modelToUse,
     tools: {
       ...tools,
       "hello-local": tool({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,9 +57,15 @@ const suggestions = {
     "Please greet the user with 'hello-local' by the name: 'user'",
 };
 
+const providerModes = [
+  { name: "AI Gateway", value: "gateway" },
+  { name: "AI SDK", value: "sdk" },
+];
+
 const ChatBotDemo = () => {
   const [input, setInput] = useState("");
   const [model, setModel] = useState<string>(models[0].value);
+  const [providerMode, setProviderMode] = useState<string>("gateway");
   const { messages, sendMessage, status } = useChat({
     onError: (error) => console.error(error),
   });
@@ -72,6 +78,7 @@ const ChatBotDemo = () => {
         {
           body: {
             model: model,
+            providerMode: providerMode,
           },
         }
       );
@@ -85,6 +92,7 @@ const ChatBotDemo = () => {
       {
         body: {
           model: model,
+          providerMode: providerMode,
         },
       }
     );
@@ -175,6 +183,26 @@ const ChatBotDemo = () => {
           />
           <PromptInputToolbar>
             <PromptInputTools>
+              <PromptInputModelSelect
+                onValueChange={(value) => {
+                  setProviderMode(value);
+                }}
+                value={providerMode}
+              >
+                <PromptInputModelSelectTrigger>
+                  <PromptInputModelSelectValue />
+                </PromptInputModelSelectTrigger>
+                <PromptInputModelSelectContent>
+                  {providerModes.map((mode) => (
+                    <PromptInputModelSelectItem
+                      key={mode.value}
+                      value={mode.value}
+                    >
+                      {mode.name}
+                    </PromptInputModelSelectItem>
+                  ))}
+                </PromptInputModelSelectContent>
+              </PromptInputModelSelect>
               <PromptInputModelSelect
                 onValueChange={(value) => {
                   setModel(value);


### PR DESCRIPTION
Added a provider mode selector to the chat interface that allows switching between Vercel AI Gateway and direct AI SDK access. Users can now use their own API keys (like OPENAI_API_KEY) via .env.local without needing to configure Vercel's AI Gateway integrations passthrough. The backend dynamically handles both provider modes, converting model formats as needed.

Updated readme